### PR TITLE
Fix binance buy & sell methods when running in production

### DIFF
--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -23,12 +23,20 @@ from __future__ import (absolute_import, division, print_function,
 
 import collections
 import json
+import os
 
 from backtrader import BrokerBase, OrderBase, Order
 from backtrader.position import Position
 from backtrader.utils.py3 import queue, with_metaclass
 
 from .ccxtstore import CCXTStore
+
+
+PRODUCTION = "production"
+DEVELOPMENT = "development"
+BINANCE = "binance"
+ENV = os.getenv("ENVIRONMENT", DEVELOPMENT)
+BROKER = os.getenv("BROKER", None)
 
 
 class CCXTOrder(OrderBase):
@@ -139,7 +147,10 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
         self.startingcash = self.store._cash
         self.startingvalue = self.store._value
 
-        self.use_order_params = True
+        running_in_production = ENV.lower() == PRODUCTION
+        broker_is_binance = BROKER.lower() == BINANCE
+
+        self.use_order_params = False if running_in_production and broker_is_binance else True
 
     def get_balance(self):
         self.store.get_balance()

--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -32,11 +32,11 @@ from backtrader.utils.py3 import queue, with_metaclass
 from .ccxtstore import CCXTStore
 
 
-PRODUCTION = "production"
-DEVELOPMENT = "development"
-BINANCE = "binance"
-ENV = os.getenv("ENVIRONMENT", DEVELOPMENT)
-BROKER = os.getenv("BROKER", None)
+PRODUCTION = "PRODUCTION"
+DEVELOPMENT = "DEVELOPMENT"
+BINANCE = "BINANCE"
+ENV = os.getenv("ENVIRONMENT", DEVELOPMENT).upper()
+BROKER = os.getenv("BROKER", "undefined").upper()
 
 
 class CCXTOrder(OrderBase):
@@ -147,8 +147,8 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
         self.startingcash = self.store._cash
         self.startingvalue = self.store._value
 
-        running_in_production = ENV.lower() == PRODUCTION
-        broker_is_binance = BROKER.lower() == BINANCE
+        running_in_production = ENV == PRODUCTION
+        broker_is_binance = BROKER == BINANCE
 
         self.use_order_params = False if running_in_production and broker_is_binance else True
 


### PR DESCRIPTION
When running w/ binance broker in production environment, buy & sell methods are returning
`-1104 UNREAD_PARAMETERS`

Due to additional param `created` from backtrader being sent to binance

Currently ccxtbroker is entering this [else condition](https://github.com/RASM01/bt-ccxt-store/blob/master/ccxtbt/ccxtbroker.py#L240)
When it should be entering this [if statement](https://github.com/RASM01/bt-ccxt-store/blob/master/ccxtbt/ccxtbroker.py#L237)
To prevent sending additional parameters.

Setting `self.use_order_params = False` when running with environment variables
`BROKER=BINANCE` & `ENVIRONMENT=PRODUCTION` fixes the issue.